### PR TITLE
Add dark theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ class MyApp extends StatelessWidget {
         accentColor: Colors.black,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
+      darkTheme: ThemeData.dark(),
       routes: {
         '/': (context) => Loading(),
         '/home': (context) => Home(),


### PR DESCRIPTION
Add dark theme, depending on if device is set to auto, light, or dark.

This can improve battery life of device.