### PR TITLE
Fix issue with tags by updating to taskc v0.0.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -573,11 +573,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "3f87abb9c4ce4aaaa4fbb5848bfafbd8a0cfc84f"
-      resolved-ref: "3f87abb9c4ce4aaaa4fbb5848bfafbd8a0cfc84f"
+      ref: "v0.0.0"
+      resolved-ref: "925c9305bc1be916ab2ee4ab91d83a0bfb8891b4"
       url: "git://github.com/bradyt/taskd-client-dart.git"
     source: git
-    version: "0.0.0-alpha.0"
+    version: "0.0.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
     # path: ../taskd-client-dart
     git:
       url: git://github.com/bradyt/taskd-client-dart.git
-      ref: 3f87abb9c4ce4aaaa4fbb5848bfafbd8a0cfc84f
+      ref: v0.0.0
   file_picker_writable: ^1.2.0+1
   hive: ^1.4.4+1
   hive_flutter: ^0.3.1


### PR DESCRIPTION
With the older version of taskc library, the `Task.fromJson` method could not parse the form like

```dart
'{"tags":["+foo"]}'
```

A test for this has been added to the taskc library, the fix implemented, and a first tag for `v0.0.0` has been pushed.

This PR updates pubspec.yaml to use taskc ref `v0.0.0`.