### PR TITLE
Pending tasks

### DIFF
--- a/lib/components/home.dart
+++ b/lib/components/home.dart
@@ -38,16 +38,24 @@ class Home extends StatelessWidget {
       ),
       body: ValueListenableBuilder(
         valueListenable: getDataBoxListenable(),
-        builder: (context, box, _) => Container(
-          margin: EdgeInsets.all(5),
-          child: ListView.builder(
-            itemCount: box.toMap().entries.length,
-            itemBuilder: (buildContext, i) {
-              return TodoCard(
-                  task: Task.fromJson(box.toMap().entries.elementAt(i).value));
-            },
-          ),
-        ),
+        builder: (context, box, _) {
+          var tasks = box
+              .toMap()
+              .map((key, value) => MapEntry(key, Task.fromJson(value)))
+              .entries
+              .where((entry) => entry.value.status == 'pending')
+              .toList();
+
+          return Container(
+            margin: EdgeInsets.all(5),
+            child: ListView.builder(
+              itemCount: tasks.length,
+              itemBuilder: (buildContext, i) {
+                return TodoCard(task: tasks.elementAt(i).value);
+              },
+            ),
+          );
+        },
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {


### PR DESCRIPTION
Match the default task view in only showing `pending` tasks, filtering status such as `completed`.

Here is the default taskwarrior report, called "next", with default configuration:

```
% task show default.command

Config Variable Value
default.command next

% task show report.next

Config Variable         Value                                                                                                                          
report.next.columns     id,start.age,entry.age,depends,priority,project,tags,recur,scheduled.countdown,due.relative,until.remaining,description,urgency
report.next.description Most urgent tasks
report.next.filter      status:pending limit:page
report.next.labels      ID,Active,Age,Deps,P,Project,Tag,Recur,S,Due,Until,Description,Urg
report.next.sort        urgency-
```

So we see that it filters on `status:pending`, which this pull request addresses. An urgency function is currently being worked on, and that would help to address the default sort, where we see `urgency-`.